### PR TITLE
Allow exploring early rooms without sequential unlocking

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,11 +379,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="galleryTitle">Pasillo lateral</h2>
         <p>
-          Una puerta corredera conduce al vestidor de mapas. Parece necesitar la pista correcta
-          para deslizarse.
+          Una puerta corredera conduce al vestidor de mapas. Puedes cruzarla en cuanto quieras
+          explorar más allá del estudio.
         </p>
         <p id="galleryStatus" class="modal__status" role="status">
-          Primero descifra el cuaderno para recordar la palabra clave.
+          El pasillo está listo. Cuando termines de mirar el cuaderno, o antes, puedes avanzar.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="gallery" disabled>
           Entrar al vestidor
@@ -403,11 +403,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="terraceTitle">Escalera al mirador</h2>
         <p>
-          El vestidor se abre a una escalera iluminada por luces neón. Un sensor detecta la
-          secuencia correcta del baúl antes de dejarte subir.
+          El vestidor se abre a una escalera iluminada por luces neón. El sensor acepta la pista
+          del cuaderno o la secuencia del baúl antes de dejarte subir.
         </p>
         <p id="terraceStatus" class="modal__status" role="status">
-          Completa la secuencia de imanes para activar el mecanismo.
+          Resuelve el cuaderno o el baúl favorito para encender la escalera.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="terrace" disabled>
           Subir al mirador


### PR DESCRIPTION
## Summary
- allow the pasillo travel to start unlocked and make the mirador staircase open after either the diary or chest puzzle
- add reusable helpers to evaluate travel unlock conditions so the UI stays in sync when resetting or solving clues
- refresh the gallery and terrace modal copy to describe the more flexible progression

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d80160383c832bacab80b3c978ed26