### PR TITLE
Add navigation map and ambient exploration to escape room

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,52 +30,52 @@ const ROOMS = [
   {
     key: "estudio",
     note:
-      "El estudio está cubierto de mapas y recuerdos. El cuaderno en el escritorio contiene la primera pista del viaje.",
+      "El estudio vibra con mapas iluminados y olor a tinta fresca. El cuaderno de viaje late como un corazón que guarda la primera coordenada.",
   },
   {
     key: "vestidor",
     note:
-      "El vestidor neón brilla con maletas abiertas. Encuentra el baúl magnético y pulsa la secuencia favorita.",
+      "El vestidor neón chisporrotea con maletas abiertas y pistas cosidas al forro. El baúl magnético promete revelar una secuencia secreta.",
   },
   {
     key: "mirador",
     note:
-      "Desde el mirador nocturno debes ajustar las luces, la persiana y la música para revelar un reflejo secreto.",
+      "El mirador nocturno parpadea entre luces, persianas y música. Ajusta el ambiente correcto para despertar el reflejo oculto.",
   },
   {
     key: "biblioteca",
     note:
-      "La biblioteca oculta libros iluminados. Ordena las letras brillantes para formar la palabra clave.",
+      "La biblioteca susurra historias y alumbra títulos prohibidos. Ordena las letras doradas para pronunciar la palabra clave.",
   },
   {
     key: "archivo",
     note:
-      "Los archivos clasificados guardan expedientes con sellos de colores. Selecciona solo los que brillan en dorado y violeta.",
+      "El archivo blindado guarda expedientes con sellos cromáticos. Solo los timbres dorado y violeta abren el registro clandestino.",
   },
   {
     key: "laboratorio",
     note:
-      "En el laboratorio las lámparas de neón reaccionan a la temperatura exacta. Ajusta el control hasta 68°.",
+      "El laboratorio de luz tiembla al ritmo del termostato. Encuentra la temperatura exacta para domar la mezcla fluorescente.",
   },
   {
     key: "observatorio",
     note:
-      "El planetario proyecta constelaciones. Escoge la figura en forma de cometa para enviar la señal correcta.",
+      "El observatorio proyecta constelaciones suspendidas. El cometa correcto enviará una llamada a través del domo.",
   },
   {
     key: "radio",
     note:
-      "La cabina de radio espera la frecuencia perfecta. Gira el dial hasta alcanzar los 98.7 FM.",
+      "La cabina de radio zumba con interferencias. Ajusta el dial hasta que la frecuencia 98.7 FM cante su número oculto.",
   },
   {
     key: "greenhouse",
     note:
-      "El invernadero violeta requiere el clima ideal. Ajusta temperatura templada y humedad al 70%.",
+      "El invernadero violeta respira vapor aromático. Equilibra clima templado y humedad exacta para que las flores revelen el código.",
   },
   {
     key: "lounge",
     note:
-      "El salón final vibra con luces cálidas. Activa la caja musical para conseguir la última cifra antes de abrir la puerta.",
+      "El salón del festejo destella con luces cálidas. Despierta la caja musical para liberar la última cifra y abrir la puerta final.",
   },
 ];
 
@@ -84,75 +84,89 @@ const TRAVELS = {
     unlockType: "immediate",
     requirements: [],
     to: "vestidor",
-    lockedText: "El pasillo está esperando. Decide cuándo cruzarlo.",
-    unlockedText: "El pasillo lateral está libre. Entra al vestidor luminoso cuando quieras.",
-    note: "Cruzas al vestidor iluminado, listo para activar la secuencia magnética.",
+    lockedText: "El pasillo está en penumbra, aguardando a que reúnas valor para cruzarlo.",
+    unlockedText:
+      "El panel corredero se aparta y un resplandor fucsia invita a explorar el vestidor de neón.",
+    note: "Te deslizas por el pasillo lateral y entras en el vestidor chispeante.",
   },
   terrace: {
     unlockType: "any",
     requirements: ["diary", "chest"],
     to: "mirador",
-    lockedText: "Resuelve el cuaderno o el baúl para activar la escalera al mirador.",
+    lockedText: "El acceso al mirador permanece sellado hasta que descifres el cuaderno o el baúl.",
     unlockedText:
-      "Las luces del baúl o la pista del cuaderno encienden la escalera al mirador. Continúa arriba.",
-    note: "Llegas al mirador nocturno donde las ventanas dominan la vista de la ciudad.",
+      "Las notas del cuaderno o la secuencia del baúl iluminan la escalera hacia el mirador panorámico.",
+    note: "Asciendes al mirador nocturno, donde la ciudad titila bajo tus pies.",
   },
   library: {
     unlockType: "all",
     requirements: ["window"],
     to: "biblioteca",
-    lockedText: "Ajusta la ventana nocturna para descubrir la palabra luminosa.",
-    unlockedText: "El reflejo revela el código y la puerta de la biblioteca se desliza.",
-    note: "La biblioteca huele a páginas antiguas. Busca la estantería que brilla.",
+    lockedText: "La biblioteca resiste. Ajusta la ventana nocturna para invocar la contraseña luminosa.",
+    unlockedText:
+      "El reflejo de la ventana revela la palabra secreta y la puerta corrediza se abre sin ruido.",
+    note: "La biblioteca te envuelve con perfume a papel antiguo y destellos dorados.",
   },
   archives: {
     unlockType: "all",
     requirements: ["bookshelf"],
     to: "archivo",
-    lockedText: "Primero descifra la palabra escondida entre los libros.",
-    unlockedText: "Las letras se acomodan y el archivo clasificado se desbloquea.",
-    note: "Te adentras entre expedientes secretos y sellos de colores.",
+    lockedText: "Aún falta recomponer la palabra oculta entre los libros iluminados.",
+    unlockedText:
+      "Las letras se alinean, un sello magnético chasquea y el archivo clasificado cede su cerradura.",
+    note: "Cruzas hacia el archivo blindado, rodeado de expedientes codificados.",
   },
   labgate: {
     unlockType: "all",
     requirements: ["archive"],
     to: "laboratorio",
-    lockedText: "Selecciona los expedientes correctos para liberar el acceso.",
-    unlockedText: "Los sellos correctos iluminan la puerta del laboratorio.",
-    note: "El laboratorio vibra con luces neón esperando la temperatura ideal.",
+    lockedText: "Las puertas del laboratorio se alimentan de los sellos dorado y violeta correctos.",
+    unlockedText:
+      "Los sellos brillan al unísono y la compuerta del laboratorio se desliza entre destellos.",
+    note: "El laboratorio vibra con neones expectantes y tubos centelleantes.",
   },
   observatoryGate: {
     unlockType: "all",
     requirements: ["laboratory"],
     to: "observatorio",
-    lockedText: "Calibra la mezcla luminosa hasta alcanzar la temperatura correcta.",
-    unlockedText: "Las lámparas zumban y abren la escalera al planetario.",
-    note: "Subes al planetario donde tres constelaciones flotan en el domo.",
+    lockedText: "El planetario sigue oscuro hasta que estabilices la mezcla luminosa.",
+    unlockedText:
+      "Los tubos neón emiten un zumbido triunfal y liberan la escalera en espiral hacia el domo.",
+    note: "Subes al observatorio privado, rodeado de constelaciones flotantes.",
   },
   radioGate: {
     unlockType: "all",
     requirements: ["observatory"],
     to: "radio",
-    lockedText: "Necesitas proyectar la constelación adecuada antes de descender.",
-    unlockedText: "La señal del cometa desbloquea la puerta hacia la cabina de radio.",
-    note: "La cabina de radio brilla con perillas y paneles iluminados.",
+    lockedText: "La cabina de radio permanece cerrada sin la señal del cometa.",
+    unlockedText:
+      "El cometa proyectado envía una ráfaga eléctrica que abre el acceso a la cabina de radio.",
+    note: "Desciendes entre cables incandescentes hacia la cabina llena de controles.",
   },
   greenhouseGate: {
     unlockType: "all",
     requirements: ["radio"],
     to: "greenhouse",
-    lockedText: "Aún falta sintonizar la frecuencia indicada en el dial.",
-    unlockedText: "La transmisión secreta abre el paso al invernadero.",
-    note: "El aire húmedo del invernadero te envuelve con aroma a lavanda.",
+    lockedText: "El invernadero reclama una frecuencia estable para liberar sus compuertas.",
+    unlockedText:
+      "La transmisión secreta pulsa en verde y la puerta del invernadero se desliza cubierta de rocío.",
+    note: "El aire húmedo del invernadero te rodea con fragancias nocturnas.",
   },
   loungeGate: {
     unlockType: "all",
     requirements: ["greenhouse"],
     to: "lounge",
-    lockedText: "Equilibra temperatura y humedad antes de abrir el salón.",
-    unlockedText: "Los sensores verdes confirman el clima ideal y liberan el acceso final.",
-    note: "Entras al salón del festejo donde la música espera tu toque final.",
+    lockedText: "El salón sigue sellado hasta que equilibres el clima violeta del invernadero.",
+    unlockedText:
+      "Los sensores celebran el clima perfecto y la puerta del salón gira entre chispas doradas.",
+    note: "Accedes al salón resplandeciente donde la música espera tu final heroico.",
   },
+};
+
+const MAP_DEFAULT_STATUS = {
+  current: "Aquí mismo",
+  available: "Disponible",
+  visited: "Visitada",
 };
 
 function createFoundMap() {
@@ -208,6 +222,7 @@ const state = {
   currentModal: null,
   previousFocus: null,
   room: ROOMS[0].key,
+  visitedRooms: new Set([ROOMS[0].key]),
   travelUnlocked: createTravelMap(),
 };
 
@@ -296,6 +311,17 @@ elements.modals = {
   radioGate: document.getElementById("modal-radioGate"),
   greenhouseGate: document.getElementById("modal-greenhouseGate"),
   loungeGate: document.getElementById("modal-loungeGate"),
+  map: document.getElementById("modal-map"),
+  "explore-estudio": document.getElementById("modal-explore-estudio"),
+  "explore-vestidor": document.getElementById("modal-explore-vestidor"),
+  "explore-mirador": document.getElementById("modal-explore-mirador"),
+  "explore-biblioteca": document.getElementById("modal-explore-biblioteca"),
+  "explore-archivo": document.getElementById("modal-explore-archivo"),
+  "explore-laboratorio": document.getElementById("modal-explore-laboratorio"),
+  "explore-observatorio": document.getElementById("modal-explore-observatorio"),
+  "explore-radio": document.getElementById("modal-explore-radio"),
+  "explore-greenhouse": document.getElementById("modal-explore-greenhouse"),
+  "explore-lounge": document.getElementById("modal-explore-lounge"),
 };
 
 elements.sequenceButtons = Array.from(
@@ -313,8 +339,28 @@ elements.travelButtons = Object.entries(TRAVELS).reduce((acc, [key]) => {
 
 elements.hotspots = Array.from(document.querySelectorAll(".hotspot[data-target]"));
 
+elements.mapButtons = {};
+document.querySelectorAll("[data-room-target]").forEach((button) => {
+  const room = button.dataset.roomTarget;
+  if (room) {
+    elements.mapButtons[room] = button;
+  }
+});
+
+elements.mapStatuses = {};
+document.querySelectorAll("[data-room-status]").forEach((status) => {
+  const room = status.dataset.roomStatus;
+  if (room) {
+    elements.mapStatuses[room] = status;
+  }
+});
+
 elements.musicButtons = Array.from(
   document.querySelectorAll(".sequence__token[data-note]")
+);
+
+elements.ambientButtons = Array.from(
+  document.querySelectorAll(".ambient-option")
 );
 
 function findRoom(key) {
@@ -338,6 +384,10 @@ function setRoom(key, { updateNote = false, note } = {}) {
   const roomInfo = findRoom(key);
   if (!roomInfo) return;
   state.room = roomInfo.key;
+  if (!state.visitedRooms) {
+    state.visitedRooms = new Set();
+  }
+  state.visitedRooms.add(state.room);
   if (elements.room) {
     elements.room.setAttribute("data-room", state.room);
   }
@@ -346,6 +396,7 @@ function setRoom(key, { updateNote = false, note } = {}) {
   if (updateNote && nextNote) {
     updateHudNote(nextNote);
   }
+  updateMapDestinations();
 }
 
 function setTravelState(key, unlocked) {
@@ -363,6 +414,7 @@ function setTravelState(key, unlocked) {
     status.textContent = isUnlocked ? travel.unlockedText : travel.lockedText;
     status.classList.toggle("modal__status--active", isUnlocked);
   }
+  updateMapDestinations();
 }
 
 function handleTravel(event) {
@@ -383,6 +435,71 @@ function handleTravel(event) {
 function updateHudNote(text) {
   if (text) {
     elements.hudNote.textContent = text;
+  }
+}
+
+function updateMapDestinations() {
+  if (!elements.mapButtons) return;
+  Object.entries(elements.mapButtons).forEach(([room, button]) => {
+    if (!button) return;
+    const requirement = button.dataset.requirement || "";
+    const unlocked = requirement ? !!state.travelUnlocked[requirement] : true;
+    const isCurrent = state.room === room;
+    const visited = state.visitedRooms?.has(room);
+    button.disabled = !unlocked;
+    button.setAttribute("aria-disabled", unlocked ? "false" : "true");
+    button.classList.toggle("map-list__button--locked", !unlocked);
+    button.classList.toggle("map-list__button--current", isCurrent);
+    const status = elements.mapStatuses?.[room];
+    if (!status) return;
+    const lockedText = status.dataset.locked || "Ruta bloqueada";
+    const statusText = !unlocked
+      ? lockedText
+      : isCurrent
+      ? MAP_DEFAULT_STATUS.current
+      : visited
+      ? MAP_DEFAULT_STATUS.visited
+      : MAP_DEFAULT_STATUS.available;
+    status.textContent = statusText;
+    status.classList.toggle("map-list__status--locked", !unlocked);
+    status.classList.toggle("map-list__status--current", unlocked && isCurrent);
+    status.classList.toggle(
+      "map-list__status--visited",
+      unlocked && visited && !isCurrent
+    );
+  });
+}
+
+function handleMapTravel(event) {
+  const button = event.currentTarget;
+  const room = button?.dataset.roomTarget;
+  if (!room) return;
+  const requirement = button.dataset.requirement || "";
+  if (requirement && !state.travelUnlocked[requirement]) {
+    updateMapDestinations();
+    return;
+  }
+  const note = button.dataset.note;
+  setRoom(room, { updateNote: true, note });
+  closeModal();
+}
+
+function handleAmbientOption(event) {
+  const button = event.currentTarget;
+  const group = button.closest("[data-ambient-group]");
+  if (!group) return;
+  group.querySelectorAll(".ambient-option").forEach((option) => {
+    option.classList.remove("ambient-option--active");
+  });
+  button.classList.add("ambient-option--active");
+  const output = group.querySelector("[data-ambient-output]");
+  if (output) {
+    const description = button.dataset.description || "";
+    output.textContent = description;
+  }
+  const note = button.dataset.note;
+  if (note) {
+    updateHudNote(note);
   }
 }
 
@@ -408,6 +525,7 @@ function markClueSolved(key, noteText) {
   Object.keys(TRAVELS).forEach((travelKey) => {
     setTravelState(travelKey);
   });
+  updateMapDestinations();
   if (CODE_ORDER.every((clue) => state.found[clue])) {
     updateHudNote("Tienes las diez cifras. Vuelve al salón y abre la puerta final.");
   }
@@ -434,6 +552,19 @@ function openModal(key) {
   state.previousFocus = document.activeElement;
   modal.classList.remove("hidden");
   modal.setAttribute("aria-hidden", "false");
+  modal.querySelectorAll("[data-ambient-group]").forEach((group) => {
+    group.querySelectorAll(".ambient-option").forEach((button) => {
+      button.classList.remove("ambient-option--active");
+    });
+    const output = group.querySelector("[data-ambient-output]");
+    if (output) {
+      const defaultText = output.dataset.default || "Selecciona un punto para inspeccionarlo.";
+      output.textContent = defaultText;
+    }
+  });
+  if (key === "map") {
+    updateMapDestinations();
+  }
   state.currentModal = modal;
   const focusable = modal.querySelector(
     "button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])"
@@ -931,6 +1062,7 @@ function resetMusicbox() {
 function resetGame(resetVictory = false) {
   state.found = createFoundMap();
   state.travelUnlocked = createTravelMap(state.found);
+  state.visitedRooms = new Set();
   resetChestSequence();
   resetMusicSequence();
   if (resetVictory) {
@@ -1030,9 +1162,17 @@ function init() {
     if (!button) return;
     button.addEventListener("click", handleTravel);
   });
+  Object.values(elements.mapButtons).forEach((button) => {
+    if (!button) return;
+    button.addEventListener("click", handleMapTravel);
+  });
+  elements.ambientButtons.forEach((button) => {
+    button.addEventListener("click", handleAmbientOption);
+  });
   updateLabValue();
   updateRadioValue();
   updateGreenhouseValues();
+  updateMapDestinations();
 }
 
 init();

--- a/index.html
+++ b/index.html
@@ -128,12 +128,30 @@
         </button>
         <button
           type="button"
+          class="hotspot hotspot--explore hotspot--explore-estudio"
+          data-target="explore-estudio"
+          data-room="estudio"
+          aria-label="Observar los rincones del estudio"
+        >
+          Rincones
+        </button>
+        <button
+          type="button"
           class="hotspot hotspot--chest"
           data-target="chest"
           data-room="vestidor"
           aria-label="Abrir el baúl junto a la cama"
         >
           Baúl
+        </button>
+        <button
+          type="button"
+          class="hotspot hotspot--explore hotspot--explore-vestidor"
+          data-target="explore-vestidor"
+          data-room="vestidor"
+          aria-label="Recorrer los detalles del vestidor"
+        >
+          Rincones
         </button>
         <button
           type="button"
@@ -146,12 +164,29 @@
         </button>
         <button
           type="button"
+          class="hotspot hotspot--explore hotspot--explore-mirador"
+          data-target="explore-mirador"
+          data-room="mirador"
+          aria-label="Explorar los balcones del mirador"
+        >
+          Rincones
+        </button>
+        <button
+          type="button"
           class="hotspot hotspot--door"
           data-target="door"
           data-room="lounge"
           aria-label="Intentar abrir la puerta"
         >
           Puerta
+        </button>
+        <button
+          type="button"
+          class="hotspot hotspot--map"
+          data-target="map"
+          aria-label="Abrir el mapa holográfico de habitaciones"
+        >
+          Mapa
         </button>
         <button
           type="button"
@@ -191,6 +226,15 @@
         </button>
         <button
           type="button"
+          class="hotspot hotspot--explore hotspot--explore-biblioteca"
+          data-target="explore-biblioteca"
+          data-room="biblioteca"
+          aria-label="Explorar las mesas de lectura"
+        >
+          Rincones
+        </button>
+        <button
+          type="button"
           class="hotspot hotspot--archives"
           data-target="archives"
           data-room="biblioteca"
@@ -206,6 +250,15 @@
           aria-label="Revisar las carpetas selladas"
         >
           Carpetas
+        </button>
+        <button
+          type="button"
+          class="hotspot hotspot--explore hotspot--explore-archivo"
+          data-target="explore-archivo"
+          data-room="archivo"
+          aria-label="Inspeccionar los anaqueles del archivo"
+        >
+          Rincones
         </button>
         <button
           type="button"
@@ -227,6 +280,15 @@
         </button>
         <button
           type="button"
+          class="hotspot hotspot--explore hotspot--explore-laboratorio"
+          data-target="explore-laboratorio"
+          data-room="laboratorio"
+          aria-label="Revisar aparatos experimentales"
+        >
+          Rincones
+        </button>
+        <button
+          type="button"
           class="hotspot hotspot--observatory"
           data-target="observatoryGate"
           data-room="laboratorio"
@@ -242,6 +304,15 @@
           aria-label="Encender el proyector estelar"
         >
           Proyector
+        </button>
+        <button
+          type="button"
+          class="hotspot hotspot--explore hotspot--explore-observatorio"
+          data-target="explore-observatorio"
+          data-room="observatorio"
+          aria-label="Examinar el domo estelar"
+        >
+          Rincones
         </button>
         <button
           type="button"
@@ -263,6 +334,15 @@
         </button>
         <button
           type="button"
+          class="hotspot hotspot--explore hotspot--explore-radio"
+          data-target="explore-radio"
+          data-room="radio"
+          aria-label="Explorar los paneles de la cabina"
+        >
+          Rincones
+        </button>
+        <button
+          type="button"
           class="hotspot hotspot--greenhousegate"
           data-target="greenhouseGate"
           data-room="radio"
@@ -278,6 +358,15 @@
           aria-label="Ajustar los reguladores del invernadero"
         >
           Reguladores
+        </button>
+        <button
+          type="button"
+          class="hotspot hotspot--explore hotspot--explore-greenhouse"
+          data-target="explore-greenhouse"
+          data-room="greenhouse"
+          aria-label="Recorrer las pasarelas del invernadero"
+        >
+          Rincones
         </button>
         <button
           type="button"
@@ -297,6 +386,15 @@
         >
           Caja musical
         </button>
+        <button
+          type="button"
+          class="hotspot hotspot--explore hotspot--explore-lounge"
+          data-target="explore-lounge"
+          data-room="lounge"
+          aria-label="Descubrir los rincones del salón"
+        >
+          Rincones
+        </button>
       </section>
     </main>
 
@@ -312,7 +410,7 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="diaryTitle">Cuaderno de viaje</h2>
         <p>
-          Las páginas están llenas de adhesivos y boletos de avión. Una nota dice:
+          Las páginas destellan con adhesivos fluorescentes y boletos perfumados. Una nota dice:
           <em>"Mi primer destino siempre guarda la llave del resto"</em>.
         </p>
         <form id="diaryForm" class="option-list">
@@ -338,6 +436,56 @@
     </section>
 
     <section
+      id="modal-explore-estudio"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreEstudioTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreEstudioTitle">Rincones del estudio</h2>
+        <p>
+          Las paredes respiran neón y el reloj del refugio avanza sin hacer ruido. Cada objeto conserva
+          una chispa de las aventuras pasadas de Allende.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El escritorio exhibe mapas de vuelo doblados y fotografías polaroid que marcan aterrizajes improvisados. Un cupón arrugado conserva la tinta del primer viaje."
+            >
+              Escritorio de planos
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El mural de rutas une continentes con hilos fluorescentes. Al tocarlos, un cosquilleo eléctrico recorre los dedos como si cada hilo fuera una corriente aérea."
+            >
+              Mural de rutas
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El fonógrafo custodia vinilos rayados. Gira sin aguja y murmura risas lejanas mezcladas con aplausos en miniatura. Parece esperar el código correcto para volver a sonar."
+            >
+              Fonógrafo centinela
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Elige un punto del estudio para inspeccionarlo."
+          >
+            Elige un punto del estudio para inspeccionarlo.
+          </p>
+        </div>
+      </article>
+    </section>
+
+    <section
       id="modal-chest"
       class="modal hidden"
       role="dialog"
@@ -349,7 +497,7 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="chestTitle">Baúl secreto</h2>
         <p>
-          Dentro hay compartimentos con figuras magnéticas. El mensaje dice:
+          Dentro hay compartimentos magnéticos que chispean como estrellas. El mensaje dice:
           <em>"Activa la secuencia favorita de Allende"</em>.
         </p>
         <div class="sequence" role="group" aria-label="Selecciona la secuencia correcta">
@@ -368,6 +516,56 @@
     </section>
 
     <section
+      id="modal-explore-vestidor"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreVestidorTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreVestidorTitle">Brillos del vestidor</h2>
+        <p>
+          Los espejos multiplican destellos fucsias y el suelo guarda huellas de bailes clandestinos.
+          El vestidor es un manifiesto portátil de viajes improvisados.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El espejo infinito proyecta versiones de ti sosteniendo maletas selladas. Cada reflejo susurra un destino distinto, esperando la contraseña correcta."
+            >
+              Espejo infinito
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El perchero luce máscaras luminiscentes, cada una marcada con códigos binarios bordados en la tela. Al moverlas tintinean como si anunciaran una función secreta."
+            >
+              Perchero codificado
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un cajón transparente contiene pulseras de luz que aún conservan calor. Se activan al tacto dejando un rastro chisporroteante en el aire."
+            >
+              Cajón de luces
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Elige una pieza del vestidor para examinarla."
+          >
+            Elige una pieza del vestidor para examinarla.
+          </p>
+        </div>
+      </article>
+    </section>
+
+    <section
       id="modal-gallery"
       class="modal hidden"
       role="dialog"
@@ -379,15 +577,246 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="galleryTitle">Pasillo lateral</h2>
         <p>
-          Una puerta corredera conduce al vestidor de mapas. Puedes cruzarla en cuanto quieras
-          explorar más allá del estudio.
+          El panel corredizo exhala vapor azul y deja entrever destellos fucsias del vestidor.
+          Cruza cuando quieras que el estudio respire aire de aventura.
         </p>
         <p id="galleryStatus" class="modal__status" role="status">
-          El pasillo está listo. Cuando termines de mirar el cuaderno, o antes, puedes avanzar.
+          El pasillo aguarda entre penumbras, listo para abrirse en cuanto decidas abandonar el
+          escritorio.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="gallery" disabled>
           Entrar al vestidor
         </button>
+      </article>
+    </section>
+
+    <section
+      id="modal-map"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mapTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content modal__content--wide">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="mapTitle">Mapa holográfico</h2>
+        <p>
+          Las rutas del refugio aparecen suspendidas en el aire. Selecciona una habitación desbloqueada
+          para viajar de inmediato y seguir explorando pistas.
+        </p>
+        <ul class="map-list">
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="estudio"
+                data-requirement=""
+                data-note="Regresas al estudio donde el cuaderno y los mapas te esperan encendidos."
+              >
+                Estudio del navegante
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="estudio"
+                data-locked="El punto de partida siempre está disponible."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Centro de operaciones repleto de mapas, fotografías y el cuaderno de viaje.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="vestidor"
+                data-requirement="gallery"
+                data-note="Te deslizas al vestidor neón y las maletas vuelven a brillar."
+              >
+                Vestidor neón
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="vestidor"
+                data-locked="Activa el pasillo lateral desde el estudio para acceder."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Maletas abiertas, luces fucsias y un baúl magnético lleno de secretos.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="mirador"
+                data-requirement="terrace"
+                data-note="Corres hacia el mirador nocturno y sientes el viento encender la música."
+              >
+                Mirador nocturno
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="mirador"
+                data-locked="Necesitas activar la escalera luminosa desde el vestidor."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Terraza elevada con persianas inteligentes y reflejos que ocultan pistas.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="biblioteca"
+                data-requirement="library"
+                data-note="Te deslizas entre anaqueles dorados listos para revelar la palabra clave."
+              >
+                Biblioteca secreta
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="biblioteca"
+                data-locked="Alinea el reflejo nocturno para desbloquear la biblioteca."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Estanterías brillantes, vitrinas enigmáticas y letras que vibran con luz.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="archivo"
+                data-requirement="archives"
+                data-note="Te sumerges otra vez en el archivo blindado y sus expedientes cromáticos."
+              >
+                Archivo blindado
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="archivo"
+                data-locked="Descifra la palabra de la biblioteca para abrir el archivo."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Expedientes sellados, tubos neumáticos y sellos que brillan al ritmo de la música.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="laboratorio"
+                data-requirement="labgate"
+                data-note="Vuelves al laboratorio para ajustar mezclas fluorescentes con precisión."
+              >
+                Laboratorio lumínico
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="laboratorio"
+                data-locked="Selecciona los sellos correctos para alimentar el laboratorio."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Reactivos brillantes, osciloscopios y una temperatura que decide el avance.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="observatorio"
+                data-requirement="observatoryGate"
+                data-note="Subes al observatorio privado donde las constelaciones obedecen tus señales."
+              >
+                Observatorio privado
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="observatorio"
+                data-locked="Estabiliza la mezcla del laboratorio para liberar el domo."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Domo estelar, prismas giratorios y constelaciones que transmiten mensajes.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="radio"
+                data-requirement="radioGate"
+                data-note="Desciendes hacia la cabina y el dial vuelve a buscar la frecuencia clandestina."
+              >
+                Cabina de radio
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="radio"
+                data-locked="Necesitas proyectar el cometa correcto para abrir la cabina."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Paneles sonoros, antenas en espiral y cuadernos de locución iluminados.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="greenhouse"
+                data-requirement="greenhouseGate"
+                data-note="Vuelves al invernadero donde el clima violeta respira junto a ti."
+              >
+                Invernadero violeta
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="greenhouse"
+                data-locked="Sintoniza la frecuencia secreta para abrir el invernadero."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Pasarelas tibias, vapor aromático y sensores atentos a cada ajuste.
+            </p>
+          </li>
+          <li class="map-list__item">
+            <div class="map-list__header">
+              <button
+                type="button"
+                class="map-list__button"
+                data-room-target="lounge"
+                data-requirement="loungeGate"
+                data-note="El salón del festejo se ilumina al sentir tus pasos en dirección a la salida."
+              >
+                Salón del festejo
+              </button>
+              <span
+                class="map-list__status"
+                data-room-status="lounge"
+                data-locked="Equilibra el clima del invernadero para abrir el salón."
+              ></span>
+            </div>
+            <p class="map-list__description">
+              Luces cálidas, mesas preparadas y una puerta final esperando el código completo.
+            </p>
+          </li>
+        </ul>
       </article>
     </section>
 
@@ -403,11 +832,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="terraceTitle">Escalera al mirador</h2>
         <p>
-          El vestidor se abre a una escalera iluminada por luces neón. El sensor acepta la pista
-          del cuaderno o la secuencia del baúl antes de dejarte subir.
+          Una escalera de luz serpentea hacia el mirador. El sensor aguarda la pista del cuaderno o
+          el latido magnético del baúl antes de permitir el ascenso.
         </p>
         <p id="terraceStatus" class="modal__status" role="status">
-          Resuelve el cuaderno o el baúl favorito para encender la escalera.
+          Resuelve el cuaderno o activa la secuencia favorita para que la escalera cobre vida.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="terrace" disabled>
           Subir al mirador
@@ -427,11 +856,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="libraryTitle">Puerta a la biblioteca</h2>
         <p>
-          Los ventanales reflejan una estantería oculta. Solo al descifrar el mensaje de la
-          ventana se iluminan las letras correctas.
+          Los ventanales proyectan una estantería oculta con destellos codificados. Ajusta el
+          ambiente del mirador para que la palabra secreta se revele.
         </p>
         <p id="libraryStatus" class="modal__status" role="status">
-          Ajusta la ventana nocturna para recordar la clave luminosa.
+          Alinea luces, persiana y música hasta que el reflejo pronuncie la clave.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="library" disabled>
           Entrar a la biblioteca
@@ -451,11 +880,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="archivesTitle">Acceso al archivo</h2>
         <p>
-          Una puerta corredera bloquea el archivo clasificado. Parece que necesita una palabra
-          secreta formada con libros brillantes.
+          Una compuerta blindada protege el archivo. Solo reaccionará cuando la palabra formada en la
+          biblioteca chispee con fuerza.
         </p>
         <p id="archivesStatus" class="modal__status" role="status">
-          Descifra la estantería para revelar la contraseña.
+          Ordena las letras luminosas de la biblioteca para que el archivo te reconozca.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="archives" disabled>
           Deslizar hacia el archivo
@@ -475,11 +904,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="labgateTitle">Puerta del laboratorio</h2>
         <p>
-          Las carpetas blindadas esconden el acceso. Solo cuando ordenas los expedientes con
-          sellos dorados la cerradura reconoce tu presencia.
+          Los expedientes magnetizados vibran sobre sus rieles. Solo la combinación dorado y violeta
+          desbloquea la cerradura luminosa del laboratorio.
         </p>
         <p id="labgateStatus" class="modal__status" role="status">
-          Identifica los expedientes correctos para habilitar la puerta.
+          Selecciona los sellos dorado y violeta para que la compuerta se ilumine.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="labgate" disabled>
           Encender el laboratorio
@@ -499,11 +928,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="observatoryGateTitle">Escalera al planetario</h2>
         <p>
-          Las luces del laboratorio alimentan el ascensor. Ajusta las mezclas lumínicas para que
-          el ascenso sea seguro.
+          Una espiral metálica palpita con energía. Solo cuando el laboratorio alcance la mezcla
+          perfecta permitirá el ascenso al domo.
         </p>
         <p id="observatoryGateStatus" class="modal__status" role="status">
-          Calibra el laboratorio para continuar.
+          Ajusta temperatura y brillo del laboratorio hasta que la escalera se encienda.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="observatoryGate" disabled>
           Subir al planetario
@@ -523,11 +952,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="radioGateTitle">Escalera a la cabina</h2>
         <p>
-          El proyector estelar envía una señal a la cabina de radio. Necesitas proyectar la
-          constelación correcta para que se abra la compuerta.
+          El domo proyecta destellos hacia la cabina. Solo la figura del cometa liberará la compuerta
+          y encenderá el descenso.
         </p>
         <p id="radioGateStatus" class="modal__status" role="status">
-          Identifica la constelación favorita de Allende.
+          Elige la constelación del cometa para que la cabina se ilumine.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="radioGate" disabled>
           Bajar a la cabina
@@ -547,11 +976,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="greenhouseGateTitle">Acceso al invernadero</h2>
         <p>
-          La puerta de cristal responde a una señal de audio concreta desde la cabina. Ajusta la
-          frecuencia antes de intentar abrirla.
+          La puerta de cristal responde a ecos de radio procedentes de la cabina. Sintoniza la
+          frecuencia exacta para que el rocío desbloquee la entrada.
         </p>
         <p id="greenhouseGateStatus" class="modal__status" role="status">
-          Sintoniza la transmisión escondida.
+          Ajusta la frecuencia secreta 98.7 FM para que el invernadero te reciba.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="greenhouseGate" disabled>
           Entrar al invernadero
@@ -571,11 +1000,11 @@
         <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
         <h2 id="loungeGateTitle">Salón del festejo</h2>
         <p>
-          Entre las plantas una puerta secreta conduce al salón final. Solo la vibración correcta
-          de los reguladores permite abrirla.
+          Entre las plantas se esconde una puerta dorada. Solo el clima perfecto del invernadero
+          liberará su cerradura.
         </p>
         <p id="loungeGateStatus" class="modal__status" role="status">
-          Equilibra temperatura y humedad antes de continuar.
+          Equilibra temperatura templada y humedad al 70% para acceder al salón.
         </p>
         <button type="button" class="btn btn--secondary" data-travel="loungeGate" disabled>
           Entrar al salón
@@ -618,6 +1047,56 @@
     </section>
 
     <section
+      id="modal-explore-mirador"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreMiradorTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreMiradorTitle">Horizonte del mirador</h2>
+        <p>
+          Una brisa nocturna cuela notas musicales y el cristal vibra con reflejos púrpura.
+          Desde aquí se controla el pulso de la ciudad.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="La barandilla estelar está llena de grabados microscópicos que narran rutas aéreas. Tocar los símbolos enciende microleds que dibujan constelaciones sobre la mesa."
+            >
+              Barandilla estelar
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="La cúpula acristalada refleja tus gestos con un retardo mínimo, como si otra versión de ti ensayara combinaciones de luces al otro lado."
+            >
+              Cúpula acristalada
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Una linterna de señales descansa sobre el banco. Al girarla proyecta haces morados sobre las nubes y hace vibrar un pequeño timbre oculto."
+            >
+              Linterna de señales
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Selecciona un detalle del mirador para acercarte."
+          >
+            Selecciona un detalle del mirador para acercarte.
+          </p>
+        </div>
+      </article>
+    </section>
+
+    <section
       id="modal-bookshelf"
       class="modal hidden"
       role="dialog"
@@ -639,6 +1118,56 @@
           <button type="submit" class="btn btn--secondary">Desbloquear libros</button>
         </form>
         <p id="bookshelfFeedback" class="modal__feedback" role="status"></p>
+      </article>
+    </section>
+
+    <section
+      id="modal-explore-biblioteca"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreBibliotecaTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreBibliotecaTitle">Susurros de la biblioteca</h2>
+        <p>
+          Estantes, vitrinas y lámparas flotantes cuentan historias secretas. La luz cambia con cada
+          título pronunciado.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un globo terráqueo de cristal gira solo, iluminando ciudades con destellos dorados. Cada giro proyecta coordenadas sobre el techo abovedado."
+            >
+              Globo terráqueo
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El escritorio de traducciones guarda diccionarios intervenidos a mano. Las notas al margen brillan como tinta líquida y hablan sobre amistades en claves morse."
+            >
+              Escritorio de traducciones
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Una lámpara suspendida late al ritmo de tu respiración. Cuando te acercas, proyecta escenas holográficas de lectores bailando entre pasillos."
+            >
+              Lámpara suspendida
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Selecciona un rincón de la biblioteca para descifrarlo."
+          >
+            Selecciona un rincón de la biblioteca para descifrarlo.
+          </p>
+        </div>
       </article>
     </section>
 
@@ -680,6 +1209,56 @@
     </section>
 
     <section
+      id="modal-explore-archivo"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreArchivoTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreArchivoTitle">Secretos del archivo</h2>
+        <p>
+          Filas metálicas contienen expedientes que respiran calor y frío al mismo tiempo. El suelo
+          retumba como si debajo corriera un tren fantasma.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Los anaqueles magnéticos cambian de tonalidad al detectar tu presencia. Se ordenan solos formando palabras pasajeras que desaparecen al parpadear."
+            >
+              Anaqueles magnéticos
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Una mesa central exhibe sellos de colores guardados en cajas de cristal. Al acercarte, cada sello emite un murmullo como si enumerara misiones completadas."
+            >
+              Mesa de sellos
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un tubo neumático vibra intermitentemente. Dentro hay mensajes enrollados que describen celebraciones futuras, fechadas en horas que aún no han sucedido."
+            >
+              Tubo de mensajes
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Elige un expediente o artefacto para escucharlo."
+          >
+            Elige un expediente o artefacto para escucharlo.
+          </p>
+        </div>
+      </article>
+    </section>
+
+    <section
       id="modal-laboratory"
       class="modal hidden"
       role="dialog"
@@ -700,6 +1279,56 @@
         </div>
         <button type="button" id="labCheck" class="btn btn--secondary">Estabilizar mezcla</button>
         <p id="laboratoryFeedback" class="modal__feedback" role="status"></p>
+      </article>
+    </section>
+
+    <section
+      id="modal-explore-laboratorio"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreLaboratorioTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreLaboratorioTitle">Luces del laboratorio</h2>
+        <p>
+          Tubos fluorescentes, medidores humeantes y botellas suspendidas trabajan como si la noche
+          fuera una científica aliada.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="La mesa de reactivos vibra con burbujas luminosas que laten como luciérnagas atrapadas. Si acercas la mano, el brillo se intensifica en busca de calor."
+            >
+              Mesa de reactivos
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El osciloscopio proyecta ondas en relieve que se convierten en melodías matemáticas. Cada curva parece coincidir con la temperatura ideal del rompecabezas."
+            >
+              Osciloscopio musical
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Una balanza gravitatoria mantiene suspendidos objetos imposibles: una pluma, un trozo de meteorito y una llave que gira sobre sí misma sin caer."
+            >
+              Balanza gravitatoria
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Escoge un instrumento del laboratorio para observarlo."
+          >
+            Escoge un instrumento del laboratorio para observarlo.
+          </p>
+        </div>
       </article>
     </section>
 
@@ -738,6 +1367,56 @@
     </section>
 
     <section
+      id="modal-explore-observatorio"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreObservatorioTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreObservatorioTitle">Constelaciones privadas</h2>
+        <p>
+          El domo metálico amplifica cada respiración. Sobre ti flotan estrellas programables que
+          responden a palmadas secretas.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un atril holográfico proyecta cartas celestes que cambian al ritmo de tu pulso. Las líneas se encienden formando firmas luminosas."
+            >
+              Atril holográfico
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El sillón de observación gravita unos centímetros sobre el suelo. Al sentarte, el respaldo vibra como si alguien ajustara las estrellas desde los altavoces ocultos."
+            >
+              Sillón flotante
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un prisma giratorio de cristal derrama rayos multicolor que se deslizan por el domo. Cada giro acompaña un murmullo que suena a radio lejana."
+            >
+              Prisma giratorio
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Señala una constelación privada para investigarla."
+          >
+            Señala una constelación privada para investigarla.
+          </p>
+        </div>
+      </article>
+    </section>
+
+    <section
       id="modal-radio"
       class="modal hidden"
       role="dialog"
@@ -758,6 +1437,56 @@
         </div>
         <button type="button" id="radioCheck" class="btn btn--secondary">Sintonizar</button>
         <p id="radioFeedback" class="modal__feedback" role="status"></p>
+      </article>
+    </section>
+
+    <section
+      id="modal-explore-radio"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreRadioTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreRadioTitle">Cabina resonante</h2>
+        <p>
+          Luces ámbar iluminan paneles de transmisión. Las ondas sonoras se enredan entre cables
+          trenzados como serpientes amistosas.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El mezclador de frecuencias parpadea con barras de colores. Al deslizar un control, escuchas voces antiguas que ríen al ritmo de percusiones suaves."
+            >
+              Mezclador de frecuencias
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Una antena interior gira lentamente, alineándose con constelaciones invisibles. Cada giro libera chispas silenciosas que flotan unos segundos en el aire."
+            >
+              Antena interior
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un cuaderno de locuciones descansa abierto con frases destacadas en tinta plateada. Al tocarlas, sientes vibrar la madera del atril como si ensayara una transmisión."
+            >
+              Cuaderno de locuciones
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Escoge un panel de la cabina para acercarte."
+          >
+            Escoge un panel de la cabina para acercarte.
+          </p>
+        </div>
       </article>
     </section>
 
@@ -784,6 +1513,56 @@
         </div>
         <button type="button" id="greenhouseCheck" class="btn btn--secondary">Equilibrar ambiente</button>
         <p id="greenhouseFeedback" class="modal__feedback" role="status"></p>
+      </article>
+    </section>
+
+    <section
+      id="modal-explore-greenhouse"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreGreenhouseTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreGreenhouseTitle">Pasarelas del invernadero</h2>
+        <p>
+          Vapor aromático envuelve flores nocturnas, ventiladores suaves y vitrinas llenas de rocío
+          suspendido.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un estanque circular refleja luces moradas. Cada gota que cae dibuja ondas que forman números efímeros sobre la superficie."
+            >
+              Estanque lumínico
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El muro de helechos canta un rumor suave. Sus hojas vibran al compás de la humedad y liberan destellos plateados al ser acariciadas."
+            >
+              Muro de helechos
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un banco de madera tibia guarda mensajes grabados con láser. Al sentarte, detecta tu ritmo cardíaco y ajusta un halo de luz envolvente."
+            >
+              Banco sensorial
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Elige un sendero del invernadero para recorrerlo."
+          >
+            Elige un sendero del invernadero para recorrerlo.
+          </p>
+        </div>
       </article>
     </section>
 
@@ -815,6 +1594,56 @@
           <button type="button" id="musicSequenceReset" class="btn btn--ghost">Reiniciar notas</button>
         </div>
         <p id="musicboxFeedback" class="modal__feedback" role="status"></p>
+      </article>
+    </section>
+
+    <section
+      id="modal-explore-lounge"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="exploreLoungeTitle"
+    >
+      <div class="modal__overlay" data-action="close"></div>
+      <article class="modal__content">
+        <button type="button" class="modal__close" data-action="close" aria-label="Cerrar">×</button>
+        <h2 id="exploreLoungeTitle">Escena del salón</h2>
+        <p>
+          El salón vibra con música suspendida en el aire. Cortinas doradas se mueven sin viento y la
+          fiesta parece lista para reanudarse en cualquier momento.
+        </p>
+        <div class="ambient-explore" data-ambient-group>
+          <div class="ambient-options">
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="La mesa de banquetes luce copas que brillan desde dentro. Cada sorbo imaginario despierta aromas de frutas exóticas y risas lejanas."
+            >
+              Mesa de banquetes
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="Un proyector vintage lanza sombras danzantes sobre las paredes. Las siluetas repiten coreografías y de pronto señalan la puerta final."
+            >
+              Proyector de sombras
+            </button>
+            <button
+              type="button"
+              class="ambient-option"
+              data-description="El balcón interior abre la vista a la ciudad. Desde allí llega un eco de celebración que promete intensificarse cuando descifres el último número."
+            >
+              Balcón interior
+            </button>
+          </div>
+          <p
+            class="modal__ambient"
+            data-ambient-output
+            data-default="Explora un rincón del salón para avivar la celebración."
+          >
+            Explora un rincón del salón para avivar la celebración.
+          </p>
+        </div>
       </article>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -330,6 +330,19 @@ p {
   pointer-events: none;
 }
 
+.hotspot--map {
+  top: 6%;
+  right: 8%;
+  font-size: 0.7rem;
+  padding-inline: 0.9rem;
+}
+
+.hotspot--explore {
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  padding: 0.4rem 1rem;
+}
+
 .room[data-room="estudio"] .hotspot--desk {
   top: 58%;
   left: 26%;
@@ -338,6 +351,11 @@ p {
 .room[data-room="estudio"] .hotspot--hall {
   bottom: 18%;
   right: 14%;
+}
+
+.room[data-room="estudio"] .hotspot--explore-estudio {
+  top: 32%;
+  left: 14%;
 }
 
 .room[data-room="vestidor"] .hotspot--chest {
@@ -350,6 +368,11 @@ p {
   right: 12%;
 }
 
+.room[data-room="vestidor"] .hotspot--explore-vestidor {
+  top: 26%;
+  right: 18%;
+}
+
 .room[data-room="mirador"] .hotspot--window {
   top: 22%;
   right: 26%;
@@ -358,6 +381,11 @@ p {
 .room[data-room="mirador"] .hotspot--library {
   bottom: 18%;
   left: 18%;
+}
+
+.room[data-room="mirador"] .hotspot--explore-mirador {
+  top: 66%;
+  right: 20%;
 }
 
 .room[data-room="biblioteca"] .hotspot--books {
@@ -370,6 +398,11 @@ p {
   left: 22%;
 }
 
+.room[data-room="biblioteca"] .hotspot--explore-biblioteca {
+  top: 18%;
+  left: 20%;
+}
+
 .room[data-room="archivo"] .hotspot--folders {
   top: 48%;
   right: 28%;
@@ -378,6 +411,11 @@ p {
 .room[data-room="archivo"] .hotspot--labgate {
   bottom: 12%;
   left: 20%;
+}
+
+.room[data-room="archivo"] .hotspot--explore-archivo {
+  top: 24%;
+  right: 22%;
 }
 
 .room[data-room="laboratorio"] .hotspot--labmix {
@@ -390,6 +428,11 @@ p {
   right: 18%;
 }
 
+.room[data-room="laboratorio"] .hotspot--explore-laboratorio {
+  top: 22%;
+  right: 24%;
+}
+
 .room[data-room="observatorio"] .hotspot--projector {
   top: 36%;
   left: 40%;
@@ -398,6 +441,11 @@ p {
 .room[data-room="observatorio"] .hotspot--radiohall {
   bottom: 12%;
   right: 16%;
+}
+
+.room[data-room="observatorio"] .hotspot--explore-observatorio {
+  top: 18%;
+  right: 22%;
 }
 
 .room[data-room="radio"] .hotspot--radiodial {
@@ -410,6 +458,11 @@ p {
   right: 18%;
 }
 
+.room[data-room="radio"] .hotspot--explore-radio {
+  top: 22%;
+  left: 18%;
+}
+
 .room[data-room="greenhouse"] .hotspot--garden {
   top: 40%;
   right: 30%;
@@ -420,6 +473,11 @@ p {
   left: 20%;
 }
 
+.room[data-room="greenhouse"] .hotspot--explore-greenhouse {
+  top: 22%;
+  left: 28%;
+}
+
 .room[data-room="lounge"] .hotspot--musicbox {
   top: 38%;
   left: 40%;
@@ -428,6 +486,11 @@ p {
 .room[data-room="lounge"] .hotspot--door {
   bottom: 14%;
   right: 22%;
+}
+
+.room[data-room="lounge"] .hotspot--explore-lounge {
+  top: 20%;
+  right: 24%;
 }
 
 .modal {
@@ -462,6 +525,10 @@ p {
   border: 1px solid var(--panel-border);
 }
 
+.modal__content--wide {
+  max-width: min(760px, 94vw);
+}
+
 .modal__content--victory {
   max-width: min(560px, 92vw);
   text-align: center;
@@ -490,6 +557,58 @@ p {
   margin-top: 1rem;
   color: var(--accent);
   font-weight: 600;
+}
+
+.ambient-explore {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.ambient-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ambient-option {
+  flex: 1 1 180px;
+  min-width: 160px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  padding: 0.75rem 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.ambient-option:hover,
+.ambient-option:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(247, 210, 125, 0.45);
+  box-shadow: 0 10px 24px rgba(247, 210, 125, 0.2);
+}
+
+.ambient-option--active {
+  border-color: rgba(247, 210, 125, 0.65);
+  background: rgba(247, 210, 125, 0.18);
+  color: var(--accent);
+  box-shadow: 0 12px 28px rgba(247, 210, 125, 0.25);
+}
+
+.modal__ambient {
+  min-height: 3.5rem;
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-muted);
+  line-height: 1.7;
+  transition: color 0.2s ease;
 }
 
 .modal__status {
@@ -546,6 +665,87 @@ p {
 
 .option-list--grid input[type="checkbox"] {
   accent-color: var(--accent);
+}
+
+.map-list {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.map-list__item {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 22px;
+  padding: 1.2rem 1.4rem;
+  box-shadow: 0 12px 30px rgba(8, 4, 18, 0.28);
+}
+
+.map-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.map-list__button {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 16px;
+  padding: 0.65rem 1.1rem;
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.map-list__button:hover:not(:disabled),
+.map-list__button:focus-visible:not(:disabled) {
+  transform: translateY(-2px);
+  border-color: rgba(247, 210, 125, 0.45);
+  box-shadow: 0 12px 28px rgba(247, 210, 125, 0.24);
+  color: var(--accent);
+}
+
+.map-list__button:disabled,
+.map-list__button--locked {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.map-list__button--current {
+  border-color: rgba(247, 210, 125, 0.7);
+  color: var(--accent);
+  box-shadow: 0 12px 30px rgba(247, 210, 125, 0.28);
+}
+
+.map-list__status {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--text-muted);
+}
+
+.map-list__status--locked {
+  color: var(--accent-strong);
+}
+
+.map-list__status--current {
+  color: var(--accent);
+}
+
+.map-list__status--visited {
+  color: rgba(247, 210, 125, 0.6);
+}
+
+.map-list__description {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted);
+  line-height: 1.6;
 }
 
 .sequence {


### PR DESCRIPTION
## Summary
- add an interactive navigation map that reflects unlock status and allows quick travel between rooms
- introduce ambient exploration modals and hotspots in every scenario to provide additional narrative options
- refresh travel copy and styles to match the expanded, non-linear experience

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d823e62ffc832bad006d3d6d1e8f21